### PR TITLE
Add option to link against system tomcrypt, disable precompiled binaries for mingw

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,8 +2,10 @@ project(libtomcrypt)
 
 add_library(libtomcrypt INTERFACE)
 
+option(USE_SYSTEM_TOMCRYPT "Dynamically link against system tomcrypt" OFF)
+
 target_include_directories(libtomcrypt INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/build/include")
-if (WIN32)
+if (WIN32 AND NOT MINGW)
     target_link_libraries(libtomcrypt INTERFACE 
         "${CMAKE_CURRENT_SOURCE_DIR}/build/lib/tomcrypt.lib")
 elseif (APPLE)
@@ -12,5 +14,13 @@ elseif (APPLE)
 elseif (UNIX)
     target_link_libraries(libtomcrypt INTERFACE
         "${CMAKE_CURRENT_SOURCE_DIR}/build/lib/libtomcrypt.a")
-endif()
+else ()
+    set(USE_SYSTEM_TOMCRYPT ON)
+endif ()
 
+if (USE_SYSTEM_TOMCRYPT)
+	find_package(PkgConfig REQUIRED)
+	pkg_check_modules(TOMCRYPT REQUIRED IMPORTED_TARGET libtomcrypt)
+	target_link_libraries(libtomcrypt INTERFACE "${TOMCRYPT_LIBRARIES}")
+	target_include_directories(libtomcrypt INTERFACE "${TOMCRYPT_INCLUDE_DIRS}")
+endif ()


### PR DESCRIPTION
This makes it easier to compile vita3k on systems/toolchains for which no precompiled binaries are existent (e.g. MinGW or Linux with Musl libc or misc BSD derivates)